### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/Cask
+++ b/Cask
@@ -12,7 +12,6 @@
  (depends-on "flycheck")
  (depends-on "flycheck-cask")
  (depends-on "dash")
- (depends-on "dash-functional")
  (depends-on "ecukes")
  (depends-on "el-mock")
  (depends-on "request")

--- a/org-pivotal-api.el
+++ b/org-pivotal-api.el
@@ -30,7 +30,6 @@
 
 (require 'a)
 (require 'dash)
-(require 'dash-functional)
 (require 'json)
 (require 'request)
 

--- a/org-pivotal.el
+++ b/org-pivotal.el
@@ -5,7 +5,7 @@
 ;; Author: Huy Duong <qhuyduong@hotmail.com>
 ;; URL: https://github.com/org-pivotal/org-pivotal
 ;; Version: 0.1
-;; Package-Requires: ((a "0.1.1") (dash "2.14.1") (dash-functional "1.2.0") (emacs "26.1") (request "0.3.0"))
+;; Package-Requires: ((a "0.1.1") (dash "2.18.0") (emacs "26.1") (request "0.3.0"))
 
 ;; This file is not part of GNU Emacs.
 
@@ -30,7 +30,6 @@
 
 (require 'a)
 (require 'dash)
-(require 'dash-functional)
 (require 'org)
 (require 'org-pivotal-api)
 (require 'subr-x)


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218